### PR TITLE
Add failed test

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -17,9 +17,6 @@ jobs:
             ros2-distro: foxy
           - os: ubuntu-20.04
             ros2-distro: galactic
-          - os: ubuntu-20.04
-            ros2-distro: rolling
-            experimental: true
     steps:
       - name: Checkout this repository
         uses: actions/checkout@v2.3.4

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -16,6 +16,8 @@ jobs:
           - os: ubuntu-20.04
             ros2-distro: foxy
           - os: ubuntu-20.04
+            ros2-distro: galactic
+          - os: ubuntu-20.04
             ros2-distro: rolling
             experimental: true
     steps:

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -42,7 +42,7 @@ jobs:
           mv examples/rclcpp/minimal_publisher . || true
           mv examples/rclcpp/minimal_subscriber . || true
           mv examples/rclpy/topics pytopics || true
-          rm -r examples || true
+          rm -rf examples test || true
 
       - name: Test the action
         uses: ./
@@ -54,6 +54,29 @@ jobs:
         with:
           name: Package
           path: package
+
+  action-test-failure:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        package: [failed_build]
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@v2.3.4
+
+      - name: Only test some packages
+        run: |
+          mv test/${{ matrix.package }} ${{ matrix.package }} || true
+          rm -rf test || true
+
+      - name: Test the action
+        id: failedstep
+        continue-on-error: true
+        uses: ./
+
+      - name: Fails if previous step has succeeded
+        if: ${{ steps.failedstep.outcome == 'success' }}
+        run: false
 
   action-test-with-output-dir:
     runs-on: ubuntu-20.04
@@ -72,7 +95,7 @@ jobs:
         run: |
           mv examples/rclcpp/topics cpptopics || true
           mv examples/rclpy/topics pytopics || true
-          rm -r examples || true
+          rm -rf examples test || true
 
       - name: Test the action with output directory
         uses: ./
@@ -100,7 +123,7 @@ jobs:
         run: |
           mv examples/rclcpp/topics cpptopics || true
           mv examples/rclpy/topics pytopics || true
-          rm -r examples || true
+          rm -rf examples test || true
 
       - name: Test the action with unique version
         uses: ./

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -1,9 +1,10 @@
 name: Action Test
 on:
+  workflow_dispatch:
   pull_request:
-    branches: [ main ]
+    branches: [main]
   push:
-    branches: [ main ]
+    branches: [main]
 jobs:
   action-test:
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,15 @@
 .*
 
 !.git*
+
+build
+install
+log
+
+debian
+obj-x86_64-linux-gnu
+
+CHANGELOG.rst
+
+*.deb
+*.ddeb

--- a/scripts/build-debian.bash
+++ b/scripts/build-debian.bash
@@ -13,18 +13,18 @@ do
   cd $ROOT_DIR/$PACKAGE || continue
 
   # Source ROS 2 environment
-  source /opt/ros/$ROS2_DISTRO/setup.bash || continue
+  source /opt/ros/$ROS2_DISTRO/setup.bash || exit $?
 
   # Generate Debian rules
   if [ "$UNIQUE_VERSION" == "false" ]
   then
-    bloom-generate rosdebian --ros-distro "$ROS2_DISTRO" || continue
+    bloom-generate rosdebian --ros-distro "$ROS2_DISTRO" || exit $?
   else
-    bloom-generate rosdebian --ros-distro "$ROS2_DISTRO" -i $(date +%s) || continue
+    bloom-generate rosdebian --ros-distro "$ROS2_DISTRO" -i $(date +%s) || exit $?
   fi
 
   # Build package using fakeroot
-  fakeroot debian/rules binary || continue
+  fakeroot debian/rules binary || exit $?
 
   # Install all build result
   sudo dpkg --install ../*.deb || continue

--- a/test/failed_build/CMakeLists.txt
+++ b/test/failed_build/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(failed_build)
+
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+
+add_executable(main "src/main.cpp")
+
+install(TARGETS main DESTINATION "lib/${PROJECT_NAME}")
+
+ament_package()

--- a/test/failed_build/package.xml
+++ b/test/failed_build/package.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>failed_build</name>
+  <version>0.1.0</version>
+  <description>This package must be failed during the build process</description>
+  <maintainer email="alfi.maulana.f@gmail.com">Alfi Maulana</maintainer>
+  <license>MIT License</license>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/test/failed_build/src/main.cpp
+++ b/test/failed_build/src/main.cpp
@@ -1,0 +1,6 @@
+int main(int /*argc*/, char ** /*argv*/)
+{
+  std::cout << "Hello World!" << std::endl;
+
+  return 0;
+}


### PR DESCRIPTION
- Add `action-test-failure` jobs to make sure a failed build and test is failed.
- Add test for [ROS 2 Galactic Geochelone](https://docs.ros.org/en/galactic/index.html) distribution.
- Add manual trigger for the `action-test` workflow.