### PR TITLE
feat: use -j8 during debian build

### DIFF
--- a/scripts/build-debian.bash
+++ b/scripts/build-debian.bash
@@ -24,7 +24,7 @@ do
   fi
 
   # Build package using fakeroot
-  fakeroot debian/rules binary || exit $?
+  fakeroot debian/rules binary -j8 || exit $?
 
   # Install all build result
   sudo dpkg --install ../*.deb || continue


### PR DESCRIPTION
- Defaulted to use 8 parallel jobs during Debian build.