### PR TITLE
test: remove ros 2 dashing test

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -11,8 +11,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-18.04
-            ros2-distro: dashing
           - os: ubuntu-20.04
             ros2-distro: foxy
           - os: ubuntu-20.04


### PR DESCRIPTION
Remove [ROS 2 Dashing Diademata](https://docs.ros.org/en/foxy/Releases/Release-Dashing-Diademata.html), end of life since May 2021.